### PR TITLE
Cambios en el archivo odoo-compose/docker-compose.yml

### DIFF
--- a/odoo-compose/docker-compose.yml
+++ b/odoo-compose/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - "8069:8069"
     volumes:
       - odoo-web-data:/var/lib/odoo
-      - ./config:/etc/odoo:ro
+      - ./config:/etc/odoo
       - ./addons:/mnt/my-module
   db:
     image: postgres:16


### PR DESCRIPTION
He eliminado el readonly en el volumen etc/odoo.

Motivo:
Si el volumen se encontraba en readonly no se podia modificar el archivo odoo.conf al iniciar por primera vez odoo. Esto provocaba que no se pudiera guardar la contraseña maestra dentro del archivo de configuracion y como resultado no se podia terminar la instalacion de odoo.